### PR TITLE
Several fixes

### DIFF
--- a/denops/@ddc-sources/tmux.ts
+++ b/denops/@ddc-sources/tmux.ts
@@ -40,8 +40,7 @@ export class Source extends BaseSource<Params> {
       await this.print_error(denops, "executable not found");
       return;
     }
-    const env = Deno.env.get("TMUX");
-    this.available = typeof env === "string" && env !== "";
+    this.available = true;
     this.executable = executable;
   }
 

--- a/doc/ddc-tmux.txt
+++ b/doc/ddc-tmux.txt
@@ -63,17 +63,25 @@ the same as ones `tmux list-panes` shows in default.
 PARAMS							       *ddc-tmux-params*
 
 						 *ddc-tmux-param-currentWinOnly*
-currentWinOnly	(boolean)
-		If true, it gathers candidates only from panes on the current
-		window.
+currentWinOnly		(boolean)
+			If true, it gathers candidates only from panes on the
+			current window.
 
-		Default: v:false
+			Default: v:false
+
+					     *ddc-tmux-param-excludeCurrentPane*
+excludeCurrentPane	(boolean)
+			If true, it gathers candidates from panes other than
+			the current one. This is the default behavior by
+			https://github.com/wellle/tmux-complete.vim
+
+			Default: v:false
 
 						     *ddc-tmux-param-executable*
-executable	(string)
-		Path for the executable of Universal Ctags.
+executable		(string)
+			Path for the executable of Universal Ctags.
 
-		Default: "tmux"
+			Default: "tmux"
 
 
 ==============================================================================


### PR DESCRIPTION
* 0d58985 In the current build, the `executable` param is ignored in some situations.
* 681738f 668d6b9 This achieves the behavior like [wellle/tmux-complete.vim][].
 
[wellle/tmux-complete.vim]: https://github.com/wellle/tmux-complete.vim